### PR TITLE
add support for flatpak

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,8 +3,8 @@ name: Build & Test
 on: [push]
 
 jobs:
-  build_and_test:
-    runs-on: ubuntu-22.04
+  build_snap:
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout
@@ -12,11 +12,37 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Build
+    - name: Build Snap
       id: snapcraft
       uses: snapcore/action-build@v1
 
-    - uses: actions/upload-artifact@v4
+    - name: Upload Snap Artifact
+      uses: actions/upload-artifact@v4
       with:
         name: snap
         path: ${{ steps.snapcraft.outputs.snap }}
+
+  build_flatpak:
+    runs-on: ubuntu-24.04
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-47
+      options: --privileged
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Build Flatpak
+      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+      with:
+        bundle: icloud-for-linux.flatpak
+        manifest-path: flatpak/io.github.crossplatform.icloud-for-linux.yml
+        cache-key: flatpak-builder-${{ github.sha }}
+
+    - name: Upload Flatpak Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: flatpak
+        path: icloud-for-linux.flatpak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,13 @@ add_executable(
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     find_package(PkgConfig REQUIRED)
     pkg_check_modules (gtk3 REQUIRED gtk+-3.0 IMPORTED_TARGET)
-    pkg_check_modules (webkit2 REQUIRED webkit2gtk-4.0 IMPORTED_TARGET)
+    
+    # Try webkit2gtk-4.1 first, then fallback to webkit2gtk-4.0
+    pkg_check_modules (webkit2 webkit2gtk-4.1 IMPORTED_TARGET)
+    if(NOT webkit2_FOUND)
+        pkg_check_modules (webkit2 REQUIRED webkit2gtk-4.0 IMPORTED_TARGET)
+    endif()
+    
     target_link_libraries (${PROJECT_NAME} PUBLIC pthread PkgConfig::gtk3 PkgConfig::webkit2)
 else()
     target_link_libraries(${PROJECT_NAME} "-framework WebKit")

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,0 +1,76 @@
+# Flatpak Build Instructions
+
+This directory contains the flatpak manifest for iCloud for Linux.
+
+## Prerequisites
+
+Install flatpak and flatpak-builder:
+```bash
+sudo apt install flatpak flatpak-builder  # Debian/Ubuntu
+sudo dnf install flatpak flatpak-builder  # Fedora
+```
+
+Add Flathub repository:
+```bash
+flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
+```
+
+Install the required runtime and SDK:
+```bash
+flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//49
+```
+
+Install dependency
+```bash
+sudo apt install libwebkit2gtk-4.0-dev  # Debian/Ubuntu
+sudo dnf install webkit2gtk4.0-devel    # Fedora
+```
+
+## Building
+
+From the repository root, run:
+```bash
+flatpak-builder --force-clean build flatpak/io.github.crossplatform.icloud-for-linux.yml
+```
+If you are building in a development container, you may need to use `--disable-rofiles-fuse`
+
+## Installing Locally
+
+After building, install the flatpak locally:
+```bash
+flatpak-builder --user --install --force-clean build flatpak/io.github.crossplatform.icloud-for-linux.yml
+```
+
+## Running
+
+After installation, you can launch the applications from your application menu, or via command line:
+```bash
+flatpak run io.github.crossplatform.icloud-for-linux
+```
+
+The flatpak installs multiple desktop entries for each iCloud service:
+- iCloud Mail
+- iCloud Contacts
+- iCloud Calendar
+- iCloud Photos
+- iCloud Drive
+- iCloud Notes
+- iCloud Reminders
+- iCloud Pages
+- iCloud Numbers
+- iCloud Keynote
+- iCloud Find
+
+## Uninstalling
+
+```bash
+flatpak uninstall io.github.crossplatform.icloud-for-linux
+```
+
+## Publishing to Flathub
+
+To publish this application to Flathub:
+
+1. Fork the [Flathub repository](https://github.com/flathub/flathub)
+2. Submit the manifest as a pull request
+3. Follow the [Flathub submission guidelines](https://docs.flathub.org/docs/for-app-authors/submission)

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -22,8 +22,10 @@ flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//49
 
 Install dependency
 ```bash
-sudo apt install libwebkit2gtk-4.0-dev  # Debian/Ubuntu
-sudo dnf install webkit2gtk4.0-devel    # Fedora
+sudo apt install libwebkit2gtk-4.0-dev  # Debian/Ubuntu 22
+sudo apt install libwebkit2gtk-4.1-dev  # Debian/Ubuntu 24
+sudo dnf install webkit2gtk4.0-devel    # Fedora prior 42
+sudo dnf install webkit2gtk4.1-devel    # Fedora 42
 ```
 
 ## Building

--- a/flatpak/io.github.crossplatform.icloud-for-linux.metainfo.xml
+++ b/flatpak/io.github.crossplatform.icloud-for-linux.metainfo.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.crossplatform.icloud-for-linux</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>iCloud for Linux</name>
+  <summary>Access iCloud services on Linux</summary>
+  <description>
+    <p>
+      iCloud for Linux provides native access to various iCloud services including Mail, 
+      Contacts, Calendar, Photos, Drive, Notes, Reminders, and iWork applications (Pages, 
+      Numbers, Keynote) directly on your Linux desktop.
+    </p>
+    <p>
+      Each service runs as a separate application with its own window, giving you a native-like
+      experience for accessing your iCloud data.
+    </p>
+  </description>
+  <launchable type="desktop-id">io.github.crossplatform.icloud-for-linux.mail.desktop</launchable>
+  <launchable type="desktop-id">io.github.crossplatform.icloud-for-linux.contacts.desktop</launchable>
+  <launchable type="desktop-id">io.github.crossplatform.icloud-for-linux.calendar.desktop</launchable>
+  <launchable type="desktop-id">io.github.crossplatform.icloud-for-linux.photos.desktop</launchable>
+  <launchable type="desktop-id">io.github.crossplatform.icloud-for-linux.drive.desktop</launchable>
+  <launchable type="desktop-id">io.github.crossplatform.icloud-for-linux.notes.desktop</launchable>
+  <launchable type="desktop-id">io.github.crossplatform.icloud-for-linux.reminders.desktop</launchable>
+  <launchable type="desktop-id">io.github.crossplatform.icloud-for-linux.pages.desktop</launchable>
+  <launchable type="desktop-id">io.github.crossplatform.icloud-for-linux.numbers.desktop</launchable>
+  <launchable type="desktop-id">io.github.crossplatform.icloud-for-linux.keynote.desktop</launchable>
+  <launchable type="desktop-id">io.github.crossplatform.icloud-for-linux.find.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <caption>iCloud Mail</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/cross-platform/icloud-for-linux</url>
+  <url type="bugtracker">https://github.com/cross-platform/icloud-for-linux/issues</url>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">intense</content_attribute>
+  </content_rating>
+  <releases>
+    <release version="0.26" date="2025-11-12"/>
+  </releases>
+</component>

--- a/flatpak/io.github.crossplatform.icloud-for-linux.yml
+++ b/flatpak/io.github.crossplatform.icloud-for-linux.yml
@@ -1,0 +1,82 @@
+app-id: io.github.crossplatform.icloud-for-linux
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+command: icloud-for-linux
+
+finish-args:
+  # Network access
+  - --share=network
+  # X11 and Wayland
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  # Graphics
+  - --device=dri
+  # Access to home directory
+  - --filesystem=home
+  # Pulseaudio for potential media playback
+  - --socket=pulseaudio
+  # Allow browser features
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.secrets
+  - --own-name=org.mpris.MediaPlayer2.icloud-for-linux
+
+modules:
+  - name: icloud-for-linux
+    buildsystem: cmake
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: dir
+        path: ..
+    post-install:
+      # Install metainfo
+      - install -Dm644 flatpak/io.github.crossplatform.icloud-for-linux.metainfo.xml /app/share/metainfo/io.github.crossplatform.icloud-for-linux.metainfo.xml
+      # Install desktop files
+      - install -Dm644 snap/gui/mail.desktop /app/share/applications/io.github.crossplatform.icloud-for-linux.mail.desktop
+      - install -Dm644 snap/gui/contacts.desktop /app/share/applications/io.github.crossplatform.icloud-for-linux.contacts.desktop
+      - install -Dm644 snap/gui/calendar.desktop /app/share/applications/io.github.crossplatform.icloud-for-linux.calendar.desktop
+      - install -Dm644 snap/gui/photos.desktop /app/share/applications/io.github.crossplatform.icloud-for-linux.photos.desktop
+      - install -Dm644 snap/gui/drive.desktop /app/share/applications/io.github.crossplatform.icloud-for-linux.drive.desktop
+      - install -Dm644 snap/gui/notes.desktop /app/share/applications/io.github.crossplatform.icloud-for-linux.notes.desktop
+      - install -Dm644 snap/gui/reminders.desktop /app/share/applications/io.github.crossplatform.icloud-for-linux.reminders.desktop
+      - install -Dm644 snap/gui/pages.desktop /app/share/applications/io.github.crossplatform.icloud-for-linux.pages.desktop
+      - install -Dm644 snap/gui/numbers.desktop /app/share/applications/io.github.crossplatform.icloud-for-linux.numbers.desktop
+      - install -Dm644 snap/gui/keynote.desktop /app/share/applications/io.github.crossplatform.icloud-for-linux.keynote.desktop
+      - install -Dm644 snap/gui/find.desktop /app/share/applications/io.github.crossplatform.icloud-for-linux.find.desktop
+      # Install icons
+      - install -Dm644 snap/gui/mail.png /app/share/icons/hicolor/256x256/apps/io.github.crossplatform.icloud-for-linux.mail.png
+      - install -Dm644 snap/gui/contacts.png /app/share/icons/hicolor/256x256/apps/io.github.crossplatform.icloud-for-linux.contacts.png
+      - install -Dm644 snap/gui/calendar.png /app/share/icons/hicolor/256x256/apps/io.github.crossplatform.icloud-for-linux.calendar.png
+      - install -Dm644 snap/gui/photos.png /app/share/icons/hicolor/256x256/apps/io.github.crossplatform.icloud-for-linux.photos.png
+      - install -Dm644 snap/gui/drive.png /app/share/icons/hicolor/256x256/apps/io.github.crossplatform.icloud-for-linux.drive.png
+      - install -Dm644 snap/gui/notes.png /app/share/icons/hicolor/256x256/apps/io.github.crossplatform.icloud-for-linux.notes.png
+      - install -Dm644 snap/gui/reminders.png /app/share/icons/hicolor/256x256/apps/io.github.crossplatform.icloud-for-linux.reminders.png
+      - install -Dm644 snap/gui/pages.png /app/share/icons/hicolor/256x256/apps/io.github.crossplatform.icloud-for-linux.pages.png
+      - install -Dm644 snap/gui/numbers.png /app/share/icons/hicolor/256x256/apps/io.github.crossplatform.icloud-for-linux.numbers.png
+      - install -Dm644 snap/gui/keynote.png /app/share/icons/hicolor/256x256/apps/io.github.crossplatform.icloud-for-linux.keynote.png
+      - install -Dm644 snap/gui/find.png /app/share/icons/hicolor/256x256/apps/io.github.crossplatform.icloud-for-linux.find.png
+      # Fix desktop file entries
+      - sed -i 's|Icon=.*|Icon=io.github.crossplatform.icloud-for-linux.mail|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.mail.desktop
+      - sed -i 's|Exec=.*|Exec=icloud-for-linux mail Mail|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.mail.desktop
+      - sed -i 's|Icon=.*|Icon=io.github.crossplatform.icloud-for-linux.contacts|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.contacts.desktop
+      - sed -i 's|Exec=.*|Exec=icloud-for-linux contacts Contacts|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.contacts.desktop
+      - sed -i 's|Icon=.*|Icon=io.github.crossplatform.icloud-for-linux.calendar|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.calendar.desktop
+      - sed -i 's|Exec=.*|Exec=icloud-for-linux calendar Calendar|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.calendar.desktop
+      - sed -i 's|Icon=.*|Icon=io.github.crossplatform.icloud-for-linux.photos|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.photos.desktop
+      - sed -i 's|Exec=.*|Exec=icloud-for-linux photos Photos|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.photos.desktop
+      - sed -i 's|Icon=.*|Icon=io.github.crossplatform.icloud-for-linux.drive|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.drive.desktop
+      - sed -i 's|Exec=.*|Exec=icloud-for-linux iclouddrive Drive|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.drive.desktop
+      - sed -i 's|Icon=.*|Icon=io.github.crossplatform.icloud-for-linux.notes|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.notes.desktop
+      - sed -i 's|Exec=.*|Exec=icloud-for-linux notes Notes|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.notes.desktop
+      - sed -i 's|Icon=.*|Icon=io.github.crossplatform.icloud-for-linux.reminders|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.reminders.desktop
+      - sed -i 's|Exec=.*|Exec=icloud-for-linux reminders Reminders|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.reminders.desktop
+      - sed -i 's|Icon=.*|Icon=io.github.crossplatform.icloud-for-linux.pages|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.pages.desktop
+      - sed -i 's|Exec=.*|Exec=icloud-for-linux pages Pages|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.pages.desktop
+      - sed -i 's|Icon=.*|Icon=io.github.crossplatform.icloud-for-linux.numbers|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.numbers.desktop
+      - sed -i 's|Exec=.*|Exec=icloud-for-linux numbers Numbers|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.numbers.desktop
+      - sed -i 's|Icon=.*|Icon=io.github.crossplatform.icloud-for-linux.keynote|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.keynote.desktop
+      - sed -i 's|Exec=.*|Exec=icloud-for-linux keynote Keynote|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.keynote.desktop
+      - sed -i 's|Icon=.*|Icon=io.github.crossplatform.icloud-for-linux.find|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.find.desktop
+      - sed -i 's|Exec=.*|Exec=icloud-for-linux find Find|g' /app/share/applications/io.github.crossplatform.icloud-for-linux.find.desktop


### PR DESCRIPTION
I'm running both fedora 42 and ubuntu 24.04. I have no use of snap and prefer to switch to flatpak when using ubuntu. Flatpak is the default on fedora.

My PR 

- add support to build flatpak application without touching or modifiying the actual snap files and folders structure.
- add build in the pipeline 
- add support for webkit2gtk version 4.1 which is the default in fedora 42 and ubuntu 24 without dropping support for 4.0
- add a readme to build flatpak manually

I have a flathub account in order to create and publish the package if you want me to. But I'd rather have you doing it because you already have the control over the snap version. 

<img width="1483" height="510" alt="Capture d’écran du 2025-11-12 17-46-55" src="https://github.com/user-attachments/assets/cd834987-838b-4ed3-b050-df1d3b5486ce" />

<img width="1180" height="244" alt="Capture d’écran du 2025-11-12 17-47-10" src="https://github.com/user-attachments/assets/e1d40bfb-2220-42a4-a091-d9e1a168a783" />
